### PR TITLE
Allow to filter optimized fonts with a whitelist and a blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ module.exports = {
     new FontminPlugin({
       autodetect: true, // automatically pull unicode characters from CSS
       glyphs: ['\uf0c8' /* extra glyphs to include */],
+      // note: these settings are mutually exclusive and allowedFilesRegex has priority over skippedFilesRegex
+      allowedFilesRegex: null, // RegExp to only target specific fonts by their names
+      skippedFilesRegex: null, // RegExp to skip specific fonts by their names
     }),
   ],
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,8 @@ class FontminPlugin {
       {
         glyphs: [],
         autodetect: true,
+        allowedFilesRegex: null,
+        skippedFilesRegex: null,
       },
       options,
     )
@@ -185,11 +187,29 @@ class FontminPlugin {
   }
 
   onAdditionalAssets(compilation) {
+    const allowedFiles = this._options.allowedFilesRegex
+    const skippedFiles = this._options.skippedFilesRegex
     const fontFiles = this.findFontFiles(compilation)
     const glyphsInCss = this.findUnicodeGlyphs(compilation)
     log(`found ${glyphsInCss.length} glyphs in CSS`)
     const minifiableFonts = _(fontFiles)
       .groupBy('font')
+      .filter((font) => {
+        const fontName = font[0].font
+        if (allowedFiles instanceof RegExp) {
+          if (!fontName.match(allowedFiles)) {
+            log(`Font "${fontName}" not allowed by pattern: ${allowedFiles}.`)
+            return false
+          }
+        } else if (skippedFiles instanceof RegExp) {
+          if (fontName.match(skippedFiles)) {
+            log(`Font "${fontName}" skipped by pattern ${skippedFiles}.`)
+            return false
+          }
+        }
+
+        return true
+      })
       .values()
 
     const glyphs = this.computeFinalGlyphs(glyphsInCss)


### PR DESCRIPTION
Add two options: allowedFilesRegex & skippedFilesRegex.

Both can be null or RegExp, they're mutually exclusive and allowedFilesRegex has priority over skippedFilesRegex.

Usage example (to only target FontAwesome):
```javascript
const FontminPlugin = require('fontmin-webpack')

Encore
  .addPlugin(new FontminPlugin({
    allowedFilesRegex: /^fa-/
  }))
```

Fix https://github.com/patrickhulce/fontmin-webpack/issues/29
Fix https://github.com/patrickhulce/fontmin-webpack/issues/5