### PR TITLE
fix matching asset filenames containing querystring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ const ttf2woff2 = require('ttf2woff2')
 const Fontmin = require('fontmin')
 const RawSource = require('webpack-sources').RawSource
 
-const FONT_REGEX = /\.(eot|ttf|svg|woff|woff2)$/
+const FONT_REGEX = /\.(eot|ttf|svg|woff|woff2)(\?.+)?$/
 const TEXT_REGEX = /\.(js|css|html)$/
 const GLYPH_REGEX = /content\s*:[^};]*?('|")(.*?)\s*('|"|;)/g
 const UNICODE_REGEX = /\\([0-9a-f]{4,6})/i
@@ -18,6 +18,10 @@ function getSurrogatePair(astralCodePoint) {
   const highSurrogate = Math.floor((astralCodePoint - 0x10000) / 0x400) + 0xD800
   const lowSurrogate = ((astralCodePoint - 0x10000) % 0x400) + 0xDC00
   return [highSurrogate, lowSurrogate]
+}
+
+function getFilenameWithoutQueryString(filename) {
+  return filename.split('?', 2)[0]
 }
 
 class FontminPlugin {
@@ -64,7 +68,7 @@ class FontminPlugin {
         const font = path.basename(filename, path.extname(filename))
         return _.keys(module.buildInfo.assets).map(asset => {
           const buffer = module.buildInfo.assets[asset].source()
-          const extension = path.extname(asset)
+          const extension = path.extname(getFilenameWithoutQueryString(asset))
           return {asset, extension, font, buffer}
         })
       })
@@ -81,6 +85,7 @@ class FontminPlugin {
       )
       .flatten()
       .filter(filename => FONT_REGEX.test(filename))
+      .map(getFilenameWithoutQueryString)
       .map(filename => {
         return {
           filename,
@@ -93,15 +98,16 @@ class FontminPlugin {
       .keys()
       .filter(name => FONT_REGEX.test(name))
       .map(asset => {
+        const assetFilename = getFilenameWithoutQueryString(asset)
         const buffer = compilation.assets[asset].source()
-        const extension = path.extname(asset)
+        const extension = path.extname(assetFilename)
         const dependency = fileDependencies.find(dependency => {
           return (
             path.extname(dependency.filename) === extension &&
             buffer.length === dependency.stats.size
           )
         })
-        const filename = (dependency && dependency.filename) || asset
+        const filename = (dependency && dependency.filename) || assetFilename
         const font = path.basename(filename, extension)
         return {asset, extension, font, buffer}
       })
@@ -220,7 +226,7 @@ class FontminPlugin {
       return prev
         .then(() => this.minifyFontGroup(group, glyphs))
         .then(files => {
-          files.forEach(file => {
+          return files.forEach(file => {
             if (file.buffer.length > file.minified.length) {
               if (appendHash) {
                 const newAssetName = this.appendMinifiedFileHash(file)
@@ -244,9 +250,11 @@ class FontminPlugin {
   hashifyFontReferences(oldAssetName, newAssetName, assets) {
     Object.keys(assets).forEach(
       asset => {
-        const oldAssetNameRegex = new RegExp(oldAssetName.replace('.', '\\.'), 'g')
+        const oldAssetNameRegex = new RegExp(
+          oldAssetName.replace('.', '\\.').replace('?', '\\?'),
+          'g'
+        )
         const assetSource = assets[asset].source().toString()
-
         if (assetSource.match(oldAssetNameRegex)) {
           assets[asset] = new RawSource(assetSource.replace(oldAssetNameRegex, newAssetName))
         }

--- a/test/fixtures/webpack.config.js
+++ b/test/fixtures/webpack.config.js
@@ -5,7 +5,12 @@ module.exports = {
   output: {filename: 'out.js', path: `${__dirname}/dist`, publicPath: '/test/fixtures/dist/'},
   module: {
     rules: [
-      {test: /\.(woff|woff2)(\?v=.+)?$/, use: ['file-loader']},
+      {test: /\.(woff|woff2)(\?v=.+)?$/, use: {
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]?[contenthash]',
+        },
+      }},
       {test: /\.(svg|ttf|eot|png)(\?v=.+)?$/, use: ['file-loader']},
       {test: /\.css$/, use: ['style-loader', 'css-loader'], include: __dirname},
     ],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,10 @@ const Plugin = require('../lib')
 const DIST_FOLDER = path.join(__dirname, 'fixtures/dist/')
 const FONT_AWESOME_FOLDER = path.join(__dirname, '../node_modules/font-awesome')
 
+function getFilenameWithoutQueryString(filename) {
+  return filename.split('?', 2)[0]
+}
+
 describe('FontminPlugin', () => {
   let fontStats
   const baseConfig = require('./fixtures/webpack.config.js')
@@ -25,7 +29,8 @@ describe('FontminPlugin', () => {
 
   function collectFontStats(directory, files) {
     return _.keys(files)
-      .map(filename => {
+      .map(name => {
+        const filename = getFilenameWithoutQueryString(name)
         const filePath = `${directory}/${filename}`
         return {
           filename,
@@ -35,6 +40,7 @@ describe('FontminPlugin', () => {
         }
       })
       .filter(item => item.extension !== '.js')
+      .filter(item => item.filename !== 'OpenSans-Bold.ttf')
   }
 
   function getGlyphs() {


### PR DESCRIPTION
Fixes https://github.com/patrickhulce/fontmin-webpack/issues/57

Assets can potentially have querystrings, messing up with the FONT_REGEX not detecting fonts.
We allow querystrings in filename, and strip the querystring part anywhere we need to check extension (path package does not handle querystrings).

NOTE: If you have suggestions to improve this, let me know, i did not want to change too much the existing logic, but it's a blocker on my project.