### PR TITLE
Ability to specify the webpack compilation hook and the textRegex as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ module.exports = {
       // note: these settings are mutually exclusive and allowedFilesRegex has priority over skippedFilesRegex
       allowedFilesRegex: null, // RegExp to only target specific fonts by their names
       skippedFilesRegex: null, // RegExp to skip specific fonts by their names
+      textRegex: /\.(js|css|html)$/,  // RegExp for searching text reference
+      webpackCompilationHook: 'thisCompilation', // Webpack compilation hook (for example PurgeCss webpack plugin use 'compilation' )
     }),
   ],
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,12 @@ const fs = require('fs')
 const path = require('path')
 const crypto = require('crypto')
 const log = require('debug')('fontmin-webpack')
-
 const _ = require('lodash')
 const Fontmin = require('fontmin')
 const RawSource = require('webpack-sources').RawSource
 
 const FONT_REGEX = /\.(eot|ttf|svg|woff|woff2)(\?.+)?$/
-const TEXT_REGEX = /\.(js|css|html)$/
+const TEXT_REGEX = /\.(js|css|html|vue)$/
 const GLYPH_REGEX = /content\s*:[^};]*?('|")(.*?)\s*('|"|;)/g
 const UNICODE_REGEX = /\\([0-9a-f]{2,6})/i
 const FONTMIN_EXTENSIONS = ['eot', 'woff', 'woff2', 'svg']
@@ -261,7 +260,7 @@ class FontminPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.thisCompilation.tap('FontminPlugin', compilation => {
+    compiler.hooks.compilation.tap('FontminPlugin', compilation => {
       compilation.hooks.additionalAssets.tapPromise('FontminPlugin', () => {
         if (!compilation.modules || !compilation.assets) {
           // eslint-disable-next-line no-console

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,10 +7,11 @@ const Fontmin = require('fontmin')
 const RawSource = require('webpack-sources').RawSource
 
 const FONT_REGEX = /\.(eot|ttf|svg|woff|woff2)(\?.+)?$/
-const TEXT_REGEX = /\.(js|css|html|vue)$/
+const TEXT_REGEX = /\.(js|css|html)$/
 const GLYPH_REGEX = /content\s*:[^};]*?('|")(.*?)\s*('|"|;)/g
 const UNICODE_REGEX = /\\([0-9a-f]{2,6})/i
 const FONTMIN_EXTENSIONS = ['eot', 'woff', 'woff2', 'svg']
+const WEBPACK_COMPILATION = 'thisCompilation'
 
 function getSurrogatePair(astralCodePoint) {
   const highSurrogate = Math.floor((astralCodePoint - 0x10000) / 0x400) + 0xD800
@@ -31,6 +32,8 @@ class FontminPlugin {
         allowedFilesRegex: null,
         skippedFilesRegex: null,
         appendHash: false,
+        textRegex: TEXT_REGEX,
+        webpackCompilationHook: WEBPACK_COMPILATION,
       },
       options,
     )
@@ -115,7 +118,7 @@ class FontminPlugin {
   findUnicodeGlyphs(compilation) {
     return _(compilation.assets)
       .map((asset, name) => ({asset, name}))
-      .filter(item => TEXT_REGEX.test(item.name))
+      .filter(item => this._options.textRegex.test(item.name))
       .map(item => {
         const content = item.asset.source()
         const matches = content.match(GLYPH_REGEX) || []
@@ -260,7 +263,7 @@ class FontminPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.compilation.tap('FontminPlugin', compilation => {
+    compiler.hooks[this._options.webpackCompilationHook].tap('FontminPlugin', compilation => {
       compilation.hooks.additionalAssets.tapPromise('FontminPlugin', () => {
         if (!compilation.modules || !compilation.assets) {
           // eslint-disable-next-line no-console

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fontmin-webpack",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Minifies icon fonts to just what is used.",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
Dear Patrick,
First thanks a lot for your work. I forked for adapting it to my use. I use it with Vue3 and Purgecss-webpack-plugin.

For having all working together it needs to be run after purgecss-webpack-plugin. But:
```js
//purgecss-webpack-plugin
compiler.hooks.compilation
//fontmin-webpack
compiler.hooks.thisCompilation
```
So I added a parameter to yours for specifying the hook, default is the old value

Vue can have css in .vue files so I added another parameter for specifying the textRegex. defaulting to the old value.
Ronan