### PR TITLE
fix: support context of webpack.config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ class FontminPlugin {
       .map(filename => {
         return {
           filename,
-          stats: fs.statSync(filename),
+          stats: fs.statSync(path.join(compilation.options.context, filename)),
         }
       })
       .value()


### PR DESCRIPTION
Fix that specifying the context of webpack.config cause no such file error.


## Occurred error
- webpack.config.js
```js
module.exports = {
  //...
  context: path.resolve(__dirname, 'app'),
};
```

Run `npx webpack`
```
Error: ENOENT: no such file or directory, stat 'fonts/my-font.ttf'
```