### PR TITLE
Add fontRegex configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ module.exports = {
       // note: these settings are mutually exclusive and allowedFilesRegex has priority over skippedFilesRegex
       allowedFilesRegex: null, // RegExp to only target specific fonts by their names
       skippedFilesRegex: null, // RegExp to skip specific fonts by their names
+      fontRegex: /\.(eot|ttf|svg|woff|woff2)(\?.+)?$/, // RegExp for searching font files
       textRegex: /\.(js|css|html)$/,  // RegExp for searching text reference
       webpackCompilationHook: 'thisCompilation', // Webpack compilation hook (for example PurgeCss webpack plugin use 'compilation' )
     }),

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,9 +66,8 @@ class FontminPlugin {
     return _(Array.from(compilation.modules))
       .filter(module => this.hasFontAsset(module.buildInfo.assets))
       .map(module => {
-        const filename = Array.from(module.buildInfo.assetsInfo.values())[0].sourceFilename
-        const font = path.basename(filename, path.extname(filename))
         return _.keys(module.buildInfo.assets).map(asset => {
+          const font = path.basename(asset).split('.').shift()
           const buffer = module.buildInfo.assets[asset].source()
           const extension = path.extname(getFilenameWithoutQueryString(asset))
           return {asset, extension, font, buffer}
@@ -205,7 +204,7 @@ class FontminPlugin {
     const minifiableFonts = _(fontFiles)
       .groupBy('font')
       .filter(font => {
-        const fontName = font[0].asset.split('/').pop()
+        const fontName = font[0].font
         if (allowedFiles instanceof RegExp) {
           if (!fontName.match(allowedFiles)) {
             log(`Font "${fontName}" not allowed by pattern: ${allowedFiles}.`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -205,7 +205,7 @@ class FontminPlugin {
     const minifiableFonts = _(fontFiles)
       .groupBy('font')
       .filter(font => {
-        const fontName = font[0].font
+        const fontName = font[0].asset.split('/').pop()
         if (allowedFiles instanceof RegExp) {
           if (!fontName.match(allowedFiles)) {
             log(`Font "${fontName}" not allowed by pattern: ${allowedFiles}.`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ class FontminPlugin {
         allowedFilesRegex: null,
         skippedFilesRegex: null,
         appendHash: false,
+        fontRegex: FONT_REGEX,
         textRegex: TEXT_REGEX,
         webpackCompilationHook: WEBPACK_COMPILATION,
       },
@@ -49,7 +50,7 @@ class FontminPlugin {
   }
 
   hasFontAsset(assets) {
-    return _.find(assets, (val, key) => FONT_REGEX.test(key))
+    return _.find(assets, (val, key) => this._options.fontRegex.test(key))
   }
 
   findFontFiles(compilation) {
@@ -85,7 +86,7 @@ class FontminPlugin {
         ),
       )
       .flatten()
-      .filter(filename => FONT_REGEX.test(filename))
+      .filter(filename => this._options.fontRegex.test(filename))
       .map(getFilenameWithoutQueryString)
       .map(filename => {
         return {
@@ -97,7 +98,7 @@ class FontminPlugin {
 
     return _(compilation.assets)
       .keys()
-      .filter(name => FONT_REGEX.test(name))
+      .filter(name => this._options.fontRegex.test(name))
       .map(asset => {
         const assetFilename = getFilenameWithoutQueryString(asset)
         const buffer = compilation.assets[asset].source()


### PR DESCRIPTION
Add fontRegex option to control which file types should be processed by fontmin.

Default value: FONT_REGEX.

I didn't write any test for this because it doesn't change anything on lib behavior, it just adds more room for fine-tuning.

For example, in a project I have many SVG logos, but no SVG fonts, so it doesn't make much sense to try and find glyphs in these files.

With this option we can define which file types must be parsed at a project level :) 